### PR TITLE
Fix FindClass from attached to VM threads

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,6 +11,6 @@ import PackageDescription
 let package = Package(
     name: "java_swift",
     dependencies: [
-        .Package(url: "https://github.com/SwiftJava/CJavaVM.git", versions: Version(1,0,0)..<Version(10,0,0)),
+        .Package(url: "https://github.com/SwiftJava/CJavaVM.git", version: Version(1,1,3)),
         ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -11,6 +11,6 @@ import PackageDescription
 let package = Package(
     name: "java_swift",
     dependencies: [
-        .Package(url: "https://github.com/SwiftJava/CJavaVM.git", version: Version(1,1,3)),
+        .Package(url: "https://github.com/SwiftJava/CJavaVM.git", "1.1.3"),
         ]
 )


### PR DESCRIPTION
If you create a thread yourself (perhaps by calling pthread_create and then attaching it with AttachCurrentThread) there are no stack frames from your application. If you call FindClass from this thread, the JavaVM will start in the "system" class loader instead of the one associated with your application, so attempts to find app-specific classes will fail.

One of possible workarounds it's cache a reference to the ClassLoader object at JNI_OnLoad, and issue loadClass calls directly.